### PR TITLE
Add profile options to updating a resource pool

### DIFF
--- a/ultra_rest_client/ultra_rest_client.py
+++ b/ultra_rest_client/ultra_rest_client.py
@@ -375,10 +375,12 @@ class RestApiClient:
         if type(rdata) is not list:
             rdata = [rdata]
         rrset = {"rdata": rdata}
+        method = "patch"
         if profile:
             rrset["profile"] = profile
+            method = "put"
         uri = "/v1/zones/" + zone_name + "/rrsets/" + rtype + "/" + owner_name
-        return self.rest_api_connection.patch(uri,json.dumps(rrset))
+        return getattr(self.rest_api_connection, method)(uri,json.dumps(rrset))
 
     # delete an rrset
     def delete_rrset(self, zone_name, rtype, owner_name):

--- a/ultra_rest_client/ultra_rest_client.py
+++ b/ultra_rest_client/ultra_rest_client.py
@@ -330,7 +330,7 @@ class RestApiClient:
         return self.rest_api_connection.post("/v1/zones/" + zone_name + "/rrsets/" + rtype + "/" + owner_name, json.dumps(rrset))
 
     # edit an rrset (PUT)
-    def edit_rrset(self, zone_name, rtype, owner_name, ttl, rdata):
+    def edit_rrset(self, zone_name, rtype, owner_name, ttl, rdata, profile=None):
         """Updates an existing RRSet in the specified zone.
 
         Arguments:
@@ -344,16 +344,19 @@ class RestApiClient:
         rdata -- The updated BIND data for the RRSet as a string.
                  If there is a single resource record in the RRSet, you can pass in the single string.
                  If there are multiple resource records  in this RRSet, pass in a list of strings.
+        profile -- The profile info if this is updating a resource pool
 
         """
         if type(rdata) is not list:
             rdata = [rdata]
         rrset = {"ttl": ttl, "rdata": rdata}
+        if profile:
+            rrset["profile"] = profile
         uri = "/v1/zones/" + zone_name + "/rrsets/" + rtype + "/" + owner_name
         return self.rest_api_connection.put(uri, json.dumps(rrset))
 
     # edit an rrset's rdata (PATCH)
-    def edit_rrset_rdata(self, zone_name, rtype, owner_name, rdata):
+    def edit_rrset_rdata(self, zone_name, rtype, owner_name, rdata, profile=None):
         """Updates an existing RRSet's Rdata in the specified zone.
 
         Arguments:
@@ -366,11 +369,14 @@ class RestApiClient:
         rdata -- The updated BIND data for the RRSet as a string.
                  If there is a single resource record in the RRSet, you can pass in the single string.
                  If there are multiple resource records  in this RRSet, pass in a list of strings.
+        profile -- The profile info if this is updating a resource pool
 
         """
         if type(rdata) is not list:
             rdata = [rdata]
         rrset = {"rdata": rdata}
+        if profile:
+            rrset["profile"] = profile
         uri = "/v1/zones/" + zone_name + "/rrsets/" + rtype + "/" + owner_name
         return self.rest_api_connection.patch(uri,json.dumps(rrset))
 


### PR DESCRIPTION
When updating a resource pool, changes only take effect if a profile is sent in the rrset.