### PR TITLE
Changes to add v3 support for getting zone metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='ultra_rest_client',
-    version='0.1.4',
+    version='0.1.5',
     description='A sample Python client for communicating with the UltraDNS REST API',
     url='https://github.com/ultradns/python_rest_api_client',
     author='Jon Bodner',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='ultra_rest_client',
-    version='0.1.5',
+    version='0.2.0',
     description='A sample Python client for communicating with the UltraDNS REST API',
     url='https://github.com/ultradns/python_rest_api_client',
     author='Jon Bodner',

--- a/ultra_rest_client/ultra_rest_client.py
+++ b/ultra_rest_client/ultra_rest_client.py
@@ -179,6 +179,31 @@ class RestApiClient:
         params = build_params(q, kwargs)
         return self.rest_api_connection.get(uri, params)
 
+    # list zones for all user accounts using v3 url
+    def get_zones_v3(self, q=None, **kwargs):
+        """Returns a list of zones across all of the user's accounts.
+
+        Keyword Arguments:
+        q -- The search parameters, in a dict.  Valid keys are:
+             name - substring match of the zone name
+             zone_type - one of:
+                PRIMARY
+                SECONDARY
+                ALIAS
+        sort -- The sort column used to order the list. Valid values for the sort field are:
+                NAME
+                ACCOUNT_NAME
+                RECORD_COUNT
+                ZONE_TYPE
+        reverse -- Whether the list is ascending(False) or descending(True)
+        offset -- The position in the list for the first returned element(0 based)
+        limit -- The maximum number of rows to be returned.
+
+        """
+        uri = "/v3/zones"
+        params = build_params(q, kwargs)
+        return self.rest_api_connection.get(uri, params)
+
     # get zone metadata
     def get_zone_metadata(self, zone_name):
         """Returns the metadata for the specified zone.

--- a/ultra_rest_client/ultra_rest_client.py
+++ b/ultra_rest_client/ultra_rest_client.py
@@ -196,7 +196,6 @@ class RestApiClient:
                 RECORD_COUNT
                 ZONE_TYPE
         reverse -- Whether the list is ascending(False) or descending(True)
-        offset -- The position in the list for the first returned element(0 based)
         limit -- The maximum number of rows to be returned.
 
         """

--- a/ultra_rest_client/ultra_rest_client.py
+++ b/ultra_rest_client/ultra_rest_client.py
@@ -189,6 +189,16 @@ class RestApiClient:
         """
         return self.rest_api_connection.get("/v1/zones/" + zone_name)
 
+    # get zone metadata v3
+    def get_zone_metadata_v3(self, zone_name):
+        """Returns the metadata for the specified zone.
+
+        Arguments:
+        zone_name -- The name of the zone being returned.
+
+        """
+        return self.rest_api_connection.get("/v3/zones/" + zone_name)
+
     # delete a zone
     def delete_zone(self, zone_name):
         """Deletes the specified zone.


### PR DESCRIPTION
[root@ip-10-74-7-71 centos]# python2 mjoy_rest_client_sample.py gmonitor gmonitor
version {u'version': u'3.43.0-20220301092300.f5a678f'}
status {u'message': u'Good'}
account name GTV8
get zone metadata {u'registrarInfo': {u'nameServers': {u'missing': [u'udns1.ultradns.net.', u'udns2.ultradns.net.']}}, u'properties': {u'status': u'ACTIVE', u'lastModifiedDateTime': u'2022-02-16T18:41Z', u'name': u'mjoy-example.com.', u'dnssecStatus': u'SIGNED', u'accountName': u'GTV8', u'owner': u'gmonitor', u'resourceRecordCount': 0, u'type': u'PRIMARY'}, u'inherit': u'ALL'}
[root@ip-10-74-7-71 centos]#

[root@ip-10-74-7-71 centos]# python3 mjoy_rest_client_sample_python3.py gmonitor gmonitor
version {'version': '3.43.0-20220301092300.f5a678f'}
status {'message': 'Good'}
account name GTV8
get zone metadata current v1 {'properties': {'name': 'mjoy-example.com.', 'accountName': 'GTV8', 'type': 'PRIMARY', 'dnssecStatus': 'SIGNED', 'status': 'ACTIVE', 'owner': 'gmonitor', 'resourceRecordCount': 0, 'lastModifiedDateTime': '2022-02-16T18:41Z'}, 'registrarInfo': {'nameServers': {'missing': ['udns1.ultradns.net.', 'udns2.ultradns.net.']}}, 'inherit': 'ALL'}

get zone metadata v3 {'properties': {'name': 'mjoy-example.com.', 'accountName': 'GTV8', 'type': 'PRIMARY', 'dnssecStatus': 'SIGNED', 'status': 'ACTIVE', 'owner': 'gmonitor', 'resourceRecordCount': 0, 'lastModifiedDateTime': '2022-02-16T18:41Z'}, 'registrarInfo': {'nameServers': {'missing': ['udns1.ultradns.net.', 'udns2.ultradns.net.']}}, 'inherit': 'ALL'}
[root@ip-10-74-7-71 centos]#