### PR TITLE
The _do_call method needs a check for application/zip content

### DIFF
--- a/ultra_rest_client/connection.py
+++ b/ultra_rest_client/connection.py
@@ -108,6 +108,9 @@ class RestApiConnection:
         # if the content-type is text/plain just return the text
         if r1.headers['Content-Type'] == 'text/plain':
             return r1.text
+        # Return the bytes. Zone exports produce zip files when done in batch.
+        if resp.headers['Content-Type'] == 'application/zip':
+            return resp.content
         json_body = r1.json()
         # if this is a background task, add the task id to the body
         if r1.status_code == requests.codes.ACCEPTED:


### PR DESCRIPTION
When you send a batch zone export request and retrieve the task, the result is a zip file. The connection module has no logic for handling application/zip content, so it tries to serialize it as though it were JSON.