### PR TITLE
change default api hostname from restapi to api

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -16,7 +16,7 @@ username = sys.argv[1]
 password = sys.argv[2]
 use_http = 'False'
 use_token = 'False'
-domain = 'restapi.ultradns.com'
+domain = 'api.ultradns.com'
 
 if len(sys.argv) == 6:
     use_token = sys.argv[3]

--- a/ultra_rest_client/connection.py
+++ b/ultra_rest_client/connection.py
@@ -26,7 +26,7 @@ class RestError(Exception):
 
 
 class RestApiConnection:
-    def __init__(self, use_http=False, host="restapi.ultradns.com", access_token: str = "", refresh_token: str = ""):
+    def __init__(self, use_http=False, host="api.ultradns.com", access_token: str = "", refresh_token: str = ""):
         self.use_http = use_http
         self.host = host
         self.access_token = access_token


### PR DESCRIPTION
changing the default rest api hostname from restapi.ultradns.com to api.ultradns.com to preserve consistency with other projects