### PR TITLE
Adds get/create apex alias functionality. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ password = os.getenv('PASSWORD')
 if not username or not password:
     raise ValueError("Username and password must be set in environment variables.")
 
-client = RestApiClient(your_username, your_password)
+client = RestApiClient(username, password)
 
 domain = "udns-python-rest-client-test.com."
 
@@ -213,4 +213,3 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 ## Questions
 
 Please contact UltraDNS support if you have any questions or encounter any issues with this code.
-

--- a/ultra_rest_client/ultra_rest_client.py
+++ b/ultra_rest_client/ultra_rest_client.py
@@ -827,41 +827,6 @@ class RestApiClient:
         self.clear_task(task_id)
         return result
 
-    # Apex Alias
-    def get_apex_alias(self, zone_name):
-        """Retrieves the Apex Alias record for the specified zone.
-
-        Arguments:
-        zone_name -- The name of the zone. The trailing dot is optional.
-
-        Returns:
-        The Apex Alias record information if it exists.
-
-        Raises:
-        Exception if the record is not found or if there are permission issues.
-        """
-        return self.rest_api_connection.get(f"/v1/zones/{zone_name}/rrsets/APEXALIAS/{zone_name}")
-
-    def create_apex_alias(self, zone_name, ttl, points_to):
-        """Creates an Apex Alias record for the specified zone.
-
-        Arguments:
-        zone_name -- The name of the zone. The trailing dot is optional.
-        ttl -- The TTL (Time To Live) value for the record.
-        points_to -- The fully qualified domain name that this Apex Alias points to.
-
-        Returns:
-        The response from the API indicating success or failure.
-
-        Raises:
-        Exception if there are issues creating the record, such as conflicts with existing records.
-        """
-        rrset = {
-            "ttl": ttl,
-            "rdata": [points_to]
-        }
-        return self.rest_api_connection.post(f"/v1/zones/{zone_name}/rrsets/APEXALIAS/{zone_name}", json.dumps(rrset))
-
 def build_params(q, args):
     params = args.copy()
     if q:

--- a/ultra_rest_client/ultra_rest_client.py
+++ b/ultra_rest_client/ultra_rest_client.py
@@ -827,6 +827,41 @@ class RestApiClient:
         self.clear_task(task_id)
         return result
 
+    # Apex Alias
+    def get_apex_alias(self, zone_name):
+        """Retrieves the Apex Alias record for the specified zone.
+
+        Arguments:
+        zone_name -- The name of the zone. The trailing dot is optional.
+
+        Returns:
+        The Apex Alias record information if it exists.
+
+        Raises:
+        Exception if the record is not found or if there are permission issues.
+        """
+        return self.rest_api_connection.get(f"/v1/zones/{zone_name}/rrsets/APEXALIAS/{zone_name}")
+
+    def create_apex_alias(self, zone_name, ttl, points_to):
+        """Creates an Apex Alias record for the specified zone.
+
+        Arguments:
+        zone_name -- The name of the zone. The trailing dot is optional.
+        ttl -- The TTL (Time To Live) value for the record.
+        points_to -- The fully qualified domain name that this Apex Alias points to.
+
+        Returns:
+        The response from the API indicating success or failure.
+
+        Raises:
+        Exception if there are issues creating the record, such as conflicts with existing records.
+        """
+        rrset = {
+            "ttl": ttl,
+            "rdata": [points_to]
+        }
+        return self.rest_api_connection.post(f"/v1/zones/{zone_name}/rrsets/APEXALIAS/{zone_name}", json.dumps(rrset))
+
 def build_params(q, args):
     params = args.copy()
     if q:


### PR DESCRIPTION
This pull request introduces new functionalities to the RestApiClient class, enabling the management of Apex Alias records within specified DNS zones. These changes allow users to retrieve and create Apex Alias records via the [REST API ](https://ultra-portalstatic.ultradns.com/static/docs/REST-API_User_Guide.pdf).

**Retrieval of Apex Alias Records:**
    A new method get_apex_alias has been added. It retrieves the Apex Alias record for a given DNS zone. This method handles exceptions related to record non-existence or permission issues.

**Creation of Apex Alias Records:**
    The create_apex_alias method has been introduced, allowing the creation of an Apex Alias record with specified TTL (Time To Live) and a target domain it points to. It manages potential conflicts with existing records and other creation issues.